### PR TITLE
fix(order): Make order button function

### DIFF
--- a/application/src/components/order-form/order-form.js
+++ b/application/src/components/order-form/order-form.js
@@ -10,8 +10,8 @@ export default function OrderForm(props) {
     const [orderItem, setOrderItem] = useState("");
     const [quantity, setQuantity] = useState("1");
 
-    const menuItemChosen = (event) => setOrderItem(event.value);
-    const menuQuantityChosen = (event) => setQuantity(event.value);
+    const menuItemChosen = (event) => setOrderItem(event.target.value);
+    const menuQuantityChosen = (event) => setQuantity(event.target.value);
 
     const auth = useSelector((state) => state.auth);
 


### PR DESCRIPTION
Send the correct parameters along in the onChange functions so the
values stop getting set to undefined

Fixes #1

## Changes
_List Changes Introduced by this PR_
1. accessing event.target.value instead of event.value in the onChange callbacks

## Purpose
event.value is always undefined. event.target.value is the thing we want to send along.

## Approach
Actually accesses the data necessary

## Testing Steps
- go to the Order Form tab
- select a meal and a quantity
- hit Order It button
- go to the View Orders tab
- observe the order you placed

## Learning
Added logs to determine which part wasn't working, then looked up what should be accessed from the event to get the desired value.

Closes [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1)
