### PR TITLE
fix(order-list): make single digit min/sec show as two

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -17,7 +17,7 @@ const OrdersList = (props) => {
                     <p>Ordered by: {order.ordered_by || ''}</p>
                 </div>
                 <div className="col-md-4 d-flex view-order-middle-col">
-                    <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                    <p>Order placed at {`${createdDate.getHours()}:${String(createdDate.getMinutes()).padStart(2,'0')}:${String(createdDate.getSeconds()).padStart(2,'0')}`}</p>
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">


### PR DESCRIPTION
Casts to string, then uses the padStart function to make sure the
minute and second show up as two digits

Fixes [#2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)

## Changes
_List Changes Introduced by this PR_
1. pads minute and second on the order list page

## Purpose
Make the single digit minute and second still take up 2 digits

## Approach
Uses the String.padStart function

## Pre-Testing TODOs
- have [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1) fixed

## Testing Steps
(These could be done individually, or concurrently)
1. Go to the order page at the start of the hour
2. Place an order while the minute is less than 10
3. Go to order list page and verify the minute is two digits long

1. Go the order page
2. Place an order within 9 seconds of the minute changing
3. Go to order list page and verify the second is two digits long

## Learning
Look on Stack Overflow for best practices for padding time


Closes [Shift3/#2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)
