### PR TITLE
test(order-list): test the minute and second are always 2 digits

### DIFF
--- a/application/src/components/view-orders/ordersList.test.js
+++ b/application/src/components/view-orders/ordersList.test.js
@@ -55,4 +55,38 @@ describe('Orders List', () => {
         expect(screen.getByText(/^.*888.*$/gm)).toBeInTheDocument();
 
     });
+
+    test('renders minutes and seconds as two digits', () => {
+		const exactHour = new Date(2022, 8, 6, 10);
+		const singleMinute = new Date(2022, 8, 6, 10, 5, 0);
+		const singleSecond = new Date(2022, 8, 6, 10, 0, 3);
+		const orders = [
+			{
+				order_item: "Taco",
+				quantity: "12",
+				createdAt: exactHour,
+				_id: 1
+			},
+			{
+				order_item: "Burrito",
+				quantity: "5",
+				createdAt: singleMinute,
+				_id: 2
+			},
+			{
+				order_item: "Quesadilla",
+				quantity: "3",
+				createdAt: singleSecond,
+				_id: 3
+			},
+		];
+		render(
+			<OrdersList
+				orders={orders}
+			/>
+		)
+		expect(screen.getByText(/^.*10:00:00.*/gm)).toBeInTheDocument();
+		expect(screen.getByText(/^.*10:05:00.*/gm)).toBeInTheDocument();
+		expect(screen.getByText(/^.*10:00:03.*/gm)).toBeInTheDocument();
+	});
 })


### PR DESCRIPTION
Add a new unit test to cover exact hour, single digit minute, and single digit
second on the order list page

Fixes [Shift3/#3](https://github.com/Shift3/react-challenge-project-jan-2022/issues/3)

## Changes
1. Additional unit test. No production code.

## Purpose
Expand unit test coverage to catch truncated minute and second issues

## Approach
Adds requested unit test

## Pre-Testing TODOs
Needs fix for [Shift3/#2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)

## Testing Steps
- run unit tests with and without the fix for [Shift3/#2](https://github.com/Shift3/react-challenge-project-jan-2022/issues/2)

## Learning
Struggled to convince command line Jest to work, then looked at the README and realized I was trying to run tests incorrectly

Closes [Shift3/#3](https://github.com/Shift3/react-challenge-project-jan-2022/issues/3)
