### PR TITLE
fix(auth): grab the correct part of the payload for the username

### DIFF
--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
Grab email instead of the non-existent login part of the payload

Fixes [Shift3/#4](https://github.com/Shift3/react-challenge-project-jan-2022/issues/4)

## Changes
1. Access email instead of login in the auth payload

## Purpose
Email address wasn't making it to the order form, so all orders were from unknown

## Approach
Grabs the right part of the payload from the server response

## Pre-Testing TODOs
Needs fix for [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1)

## Testing Steps
- log in via the login form, using values for both email and password
- go to the order form page
- place an order
- go to the order list page and verify your order has the email you logged in with as the Ordered By

## Learning
console logs to figure out what what getting sent where. repo search for "token" as that was the bit of the auth that was actually making it to the order form when the login was successful

Closes [Shift3/#4](https://github.com/Shift3/react-challenge-project-jan-2022/issues/4)
