### PR TITLE
feat(logout): Logout nav functionality

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,8 +1,20 @@
 import React from "react";
+import { connect } from 'react-redux';
 import { Link } from "react-router-dom";
+import { logoutUser } from '../../redux/actions/authActions';
 import "./nav.css";
 
+const mapActionsToProps = dispatch => ({
+    commenceLogout() {
+        dispatch(logoutUser())
+    }
+})
+
 const Nav = (props) => {
+    const navLogout = () => {
+        console.log("Logging out");
+        props.commenceLogout();
+    };
     return (
         <div className="nav-strip">
             <Link to={"/order"} className="nav-link">
@@ -15,7 +27,7 @@ const Nav = (props) => {
                     <label className="nav-label">View Orders</label>
                 </div>
             </Link>
-            <Link to={"/login"} className="nav-link">
+            <Link className="nav-link" to={"/"} onClick={navLogout}>
                 <div className="nav-link-style">
                     <label className="nav-label">Log Out</label>
                 </div>
@@ -24,4 +36,4 @@ const Nav = (props) => {
     );
 }
 
-export default Nav;
+export default connect(null, mapActionsToProps)(Nav);


### PR DESCRIPTION
make the logout option the nav redirect to home and
call the logout redux function

Implements [#5](https://github.com/Shift3/react-challenge-project-jan-2022/issues/5)

## Changes
1. Logout button navigates back to the home screen
2. Logout button clears the user info from redux

## Purpose
The logout nav option didn't do anything under the hood

## Approach
Updates the link to implement the feature request

## Testing Steps
- log into the order system
- use the logout menu option
- observe that you've redirected to the home screen

Additional testing:
- if [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1) is fixed, use the browser back button to get back into the order system
- attempt to place another order
- observe that the order created doesn't have a user because you're not logged in

## Learning
Attempted to implement server side logout function, duplicated style of the login button for how it fires things off, looked up the Link react tag to find the syntax for firing off a click function

Closes [Shift3/#5](https://github.com/Shift3/react-challenge-project-jan-2022/issues/5)
