### PR TITLE
feat(routes): Add route guarding for pages that need user

### DIFF
--- a/application/src/components/login/login-form/loginForm.js
+++ b/application/src/components/login/login-form/loginForm.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux'; 
 import { loginUser } from '../../../redux/actions/authActions'
+import store from '../../../redux/store';
 
 const mapActionsToProps = dispatch => ({
   commenceLogin(email, password) {
@@ -17,7 +18,14 @@ class LoginForm extends Component {
   login(e) {
     e.preventDefault();
     this.props.commenceLogin(this.state.email, this.state.password);
-    this.props.onLogin();
+    // don't fire onLogin immediately, because the login flow hasn't finished yet
+
+    store.subscribe(() => {
+      const newState = store.getState();
+      if (newState.auth.token != null) {
+        this.props.onLogin();
+      }
+    })
   }
 
   onChange(key, val) {

--- a/application/src/redux/actions/authActions.js
+++ b/application/src/redux/actions/authActions.js
@@ -26,8 +26,10 @@ export const loginUser = (email, password) => {
         .then(response => {
             if (response.success) {
                 dispatch(finishLogin(response.email, response.token));
+            } else {
+                dispatch(logoutUser());
             }
-        })
+        });
     };
 }
 

--- a/application/src/router/appRouter.js
+++ b/application/src/router/appRouter.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import { Main, Login, OrderForm, ViewOrders} from '../components';
+import GuardedRoute from "./guardedRoute"
 
 const AppRouter = (props) => {
   return (
     <Router>
       <Route path="/" exact component={Main} />
       <Route path="/login" exact component={Login} />
-      <Route path="/order" exact component={OrderForm} />
-      <Route path="/view-orders" exact component={ViewOrders} />
+      <GuardedRoute path="/order" exact component={OrderForm} />
+      <GuardedRoute path="/view-orders" exact component={ViewOrders} />
     </Router>
   );
 }

--- a/application/src/router/guardedRoute.js
+++ b/application/src/router/guardedRoute.js
@@ -1,0 +1,31 @@
+import React from "react";
+import { connect } from 'react-redux';
+import { Route, Redirect } from "react-router-dom";
+import store from '../redux/store';
+
+const mapStateToProps = (state) => {
+  return {isLoggedIn: Boolean(state.auth.email) && Boolean(state.auth.token)};
+};
+
+const GuardedRoute = (props) => {
+  var {isLoggedIn, component, ...routeProps} = props;
+  const Component = component;
+  store.subscribe(() => {
+    const newState = store.getState();
+    isLoggedIn = Boolean(newState.auth.email) && Boolean(newState.auth.token);
+  });
+
+  return (
+    <Route
+      {...routeProps}
+      render = {(props) => {
+        if (isLoggedIn) {
+          return <Component {...props} />;
+        }
+        return <Redirect to={{path:"/login"}} />;
+      }}
+    />
+  );
+}
+
+export default connect(mapStateToProps)(GuardedRoute);


### PR DESCRIPTION
Add new class, GuardedRoute, and change the order and order list pages over
to that new type of route to prevent access without being logged in.

Implements [#6](https://github.com/Shift3/react-challenge-project-jan-2022/issues/6)

## Changes
1. New class, GuardedRoutes
2. Change the order and order list pages over to GuardedRoutes
3. Wait for a response to the login attempt on the login screen before moving on

## Purpose
Order and Order List pages are accessible without being logged in, which is a problem

## Approach
Adds a new type of route, switches the pertinent routes over to the new type, and makes
sure the login page actually waits for a response before continuing so the login status is
properly accessible

## Pre-Testing TODOs
- Needs fixes for [Shift3/#5](https://github.com/Shift3/react-challenge-project-jan-2022/issues/5) to properly test

## Testing Steps
- log in and verify that the Order and Order List pages are accessible
- use the log out button
- navigate via the address bar to either `/order` or `/view-orders` and verify it redirects to the home screen

## Learning
Looking for best practices for expanding Routes, figure out how to wait for updates before continuing. The store subscribing feels heavy handed, but it implements the feature, so I'll dig into better ways at a later time.

Closes [Shift3/#6](https://github.com/Shift3/react-challenge-project-jan-2022/issues/6)
