### PR TITLE
feat(order-list): Edit and Delete button functionality

### DIFF
--- a/application/src/components/view-orders/ordersList.js
+++ b/application/src/components/view-orders/ordersList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const OrdersList = (props) => {
-    const { orders } = props;
+    const { orders, OnEdit, OnDelete, OnEdittable, OnCancel } = props;
     if (!props || !props.orders || !props.orders.length) return (
         <div className="empty-orders">
             <h2>There are no orders to display</h2>
@@ -10,6 +10,47 @@ const OrdersList = (props) => {
 
     return orders.map(order => {
         const createdDate = new Date(order.createdAt);
+        if (order.edittable) {
+            const menuItemChosen = (event) => {
+                order.order_item = event.target.value;
+            }
+            const menuQuantityChosen = (event) => {
+                order.quantity = event.target.value;
+            }
+            return (
+                <div className="row view-order-container" key={order._id}>
+                    <div className="col-md-4 view-order-left-col p-3">
+                        <select
+                            value={order.order_item}
+                            onChange={(event) => menuItemChosen(event)}
+                            className="menu-select"
+                        >
+                            <option value="Soup of the Day">Soup of the Day</option>
+                            <option value="Linguini With White Wine Sauce">Linguini With White Wine Sauce</option>
+                            <option value="Eggplant and Mushroom Panini">Eggplant and Mushroom Panini</option>
+                            <option value="Chili Con Carne">Chili Con Carne</option>
+                        </select>
+                        <p>Ordered by: {order.ordered_by || ''}</p>
+                    </div>
+                    <div className="col-md-4 d-flex view-order-middle-col">
+                        <p>Order placed at {`${createdDate.getHours()}:${createdDate.getMinutes()}:${createdDate.getSeconds()}`}</p>
+                        <p>Quantity:
+                        <select value={order.quantity} onChange={(event) => menuQuantityChosen(event)}>
+                            <option value="1">1</option>
+                            <option value="2">2</option>
+                            <option value="3">3</option>
+                            <option value="4">4</option>
+                            <option value="5">5</option>
+                            <option value="6">6</option>
+                        </select></p>
+                    </div>
+                    <div className="col-md-4 view-order-right-col">
+                        <button className="btn btn-success" onClick={() => OnEdit(order)}>Update</button>
+                        <button className="btn btn-danger" onClick={() => OnCancel()}>Cancel</button>
+                    </div>
+                </div>
+            )
+        }
         return (
             <div className="row view-order-container" key={order._id}>
                 <div className="col-md-4 view-order-left-col p-3">
@@ -21,8 +62,8 @@ const OrdersList = (props) => {
                     <p>Quantity: {order.quantity}</p>
                 </div>
                 <div className="col-md-4 view-order-right-col">
-                    <button className="btn btn-success">Edit</button>
-                    <button className="btn btn-danger">Delete</button>
+                    <button className="btn btn-success" onClick={() => OnEdittable(order)}>Edit</button>
+                    <button className="btn btn-danger" onClick={() => OnDelete(order)}>Delete</button>
                 </div>
             </div>
         );

--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -4,26 +4,91 @@ import { SERVER_IP } from '../../private';
 import OrdersList from './ordersList';
 import './viewOrders.css';
 
+const CURRENT_ORDERS_URL = `${SERVER_IP}/api/current-orders`;
+const EDIT_ORDER_URL = `${SERVER_IP}/api/edit-order`;
+const DELETE_ORDER_URL = `${SERVER_IP}/api/delete-order`;
+
 export default function ViewOrders(props) {
     const [orders, setOrders] = useState([]);
 
-    useEffect(() => {
-        fetch(`${SERVER_IP}/api/current-orders`)
-            .then(response => response.json())
-            .then(response => {
-                if(response.success) {
-                    setOrders(response.orders);
-                } else {
-                    console.log('Error getting orders');
-                }
-            });
-    }, [])
+    // define our use functions
+    const refreshOrders = () => {
+        fetch(CURRENT_ORDERS_URL)
+        .then(response => response.json())
+        .then(response => {
+            if(response.success) {
+                setOrders(response.orders);
+            } else {
+                console.log('Error getting orders');
+            }
+        });
+    }
+
+    const editOrder = ((order) => {
+        // TODO: need to figure out what they want to edit it _to_
+        console.log("EDITTING ORDER " + JSON.stringify(order));
+        fetch(EDIT_ORDER_URL, {
+            method: `POST`,
+            body: JSON.stringify({
+                id: order._id,
+                ordered_by: order.ordered_by,
+                quantity: order.quantity,
+                order_item: order.order_item // was menu_item in the spec, but add order uses order_item, so guessing that's right
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => res.json())
+        .then(response => {
+            console.log("Edit Success", JSON.stringify(response));
+            if (response.success) {
+                refreshOrders();
+            }
+        })
+        .catch(error => console.error(error));
+	})
+
+	const edittableOrder = ((order) => {
+		// turn off editting for all the other orders to avoid weirdness
+		orders.map(o => o.edittable = false);
+		// make this one specifically edittable
+        order.edittable = true;
+        // force a refresh
+        setOrders([...orders]);
+    })
+
+	const deleteOrder = ((order) => {
+        fetch(DELETE_ORDER_URL, {
+            method: `POST`,
+            body: JSON.stringify({
+                id: order._id
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(res => res.json())
+        .then(response => {
+            if (response.success) {
+                refreshOrders();
+            }
+        })
+        .catch(error => console.error(error));
+	})
+
+    // refresh with effect
+    useEffect(refreshOrders, [])
 
     return (
         <Template>
             <div className="container-fluid">
                 <OrdersList
                     orders={orders}
+                    OnEdit = {(order) => {editOrder(order)}}
+                    OnDelete = {(order) => {deleteOrder(order)}}
+                    OnEdittable = {(order) => {edittableOrder(order)}}
+                    OnCancel = {() => {refreshOrders()}}
                 />
             </div>
         </Template>


### PR DESCRIPTION
Hook up api calls for Delete and Edit, as well as make a div
on the order list for in-line editting

Fixes [#8](https://github.com/Shift3/react-challenge-project-jan-2022/issues/8)

## Changes
1. Hooked up Delete button on order list to the delete api
2. Added in-line editting div on the order list page
3. Hooked up edit order api to the editting div

## Purpose
Edit and Delete buttons on the order view page didn't do anything

## Approach
Hooks up the edit and delete api, and make a user-understandable edit flow

## Pre-Testing TODOs
- Either a fix for [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1) or a DB already populated with orders

## Testing Steps
- navigate to the order view page (if empty, add some orders from the Order page)
- Hit the Delete button on one of the orders, and observe that the order has been deleted
- Hit the Edit button on one of the remaining orders
-- Don't change anything, hit the Update button, observe the order is unchanged and unedittable again
-- Don't change anything, hit the Cancel button, observe the order is unchanged and unedittable again
-- Hit the Edit button on a different order, observe the previous order goes back to being unedittable
-- Change item and/or quantity, hit the Cancel button, observe the order goes back to how it was
-- Change item and/or quantity, hit the Update button, observe the order is changed and back to unedittable

## Learning
Hardest part was coming up with the flow for actually editting. Ended up going with a copy/paste job from the Ordering page for the selects.

Closes [Shift3/#8](https://github.com/Shift3/react-challenge-project-jan-2022/issues/8)
