### PR TITLE
feat(nav-bar): Add display of user name to nav bar

### DIFF
--- a/application/src/components/nav/nav.js
+++ b/application/src/components/nav/nav.js
@@ -1,25 +1,32 @@
 import React from "react";
+import { useSelector } from 'react-redux';
 import { Link } from "react-router-dom";
 import "./nav.css";
 
 const Nav = (props) => {
+    const auth = useSelector((state) => state.auth);
     return (
-        <div className="nav-strip">
-            <Link to={"/order"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Order Form</label>
-                </div>
-            </Link>
-            <Link to={"/view-orders"} className="nav-link" id="middle-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">View Orders</label>
-                </div>
-            </Link>
-            <Link to={"/login"} className="nav-link">
-                <div className="nav-link-style">
-                    <label className="nav-label">Log Out</label>
-                </div>
-            </Link>
+        <div>
+            <div className="nav-strip">
+                <label className="nav-label">Welcome Back, {auth.email}</label>
+            </div>
+            <div className="nav-strip">
+                <Link to={"/order"} className="nav-link">
+                    <div className="nav-link-style">
+                        <label className="nav-label">Order Form</label>
+                    </div>
+                </Link>
+                <Link to={"/view-orders"} className="nav-link" id="middle-link">
+                    <div className="nav-link-style">
+                        <label className="nav-label">View Orders</label>
+                    </div>
+                </Link>
+                <Link to={"/login"} className="nav-link">
+                    <div className="nav-link-style">
+                        <label className="nav-label">Log Out</label>
+                    </div>
+                </Link>
+            </div>
         </div>
     );
 }

--- a/application/src/redux/reducers/authReducer.js
+++ b/application/src/redux/reducers/authReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = { email: null, token: null };
 export default (state = INITIAL_STATE, action) => {
     switch (action.type) {
         case LOGIN:
-            return { ...state, email: action.payload.login, token: action.payload.token }
+            return { ...state, email: action.payload.email, token: action.payload.token }
         case LOGOUT:
             return { ...state, ...INITIAL_STATE }
         default:


### PR DESCRIPTION
Grab the user's email from the state, and display it in the nav bar.

Fixes [#10](https://github.com/Shift3/react-challenge-project-jan-2022/issues/10)

## Changes
1. Fix for auth from PR #4 
2. Adds line to nav bar welcoming the user, displaying their email address

## Purpose
No visible sign of which user is being used unless they order, then check the list for their order

## Approach
pulls the email address from the state's auth object.

## Pre-Testing TODOs
n/a

## Testing Steps
- Go through the log-in flow, observe the email address you logged in with is displayed in the nav bar
- if you have a fix for [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1), place an order, then go to the view order page and verify the email matches

## Learning
This felt straightforward based on earlier Issues

Closes [Shift3/#10](https://github.com/Shift3/react-challenge-project-jan-2022/issues/10)
