### PR TITLE
feat(order-list): Live refresh

### DIFF
--- a/application/src/components/view-orders/viewOrders.js
+++ b/application/src/components/view-orders/viewOrders.js
@@ -1,31 +1,65 @@
-import React, { useState, useEffect } from 'react';
+import React, { Component } from 'react';
 import { Template } from '../../components';
 import { SERVER_IP } from '../../private';
 import OrdersList from './ordersList';
 import './viewOrders.css';
 
-export default function ViewOrders(props) {
-    const [orders, setOrders] = useState([]);
+const CURRENT_ORDERS_URL = `${SERVER_IP}/api/current-orders`;
+const LIVE_ORDER_MODE_URL = `${SERVER_IP}/api/live-mode`;
 
-    useEffect(() => {
-        fetch(`${SERVER_IP}/api/current-orders`)
-            .then(response => response.json())
-            .then(response => {
-                if(response.success) {
-                    setOrders(response.orders);
-                } else {
-                    console.log('Error getting orders');
-                }
-            });
-    }, [])
+class ViewOrders extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            orders: []
+        };
+    }
 
-    return (
-        <Template>
-            <div className="container-fluid">
-                <OrdersList
-                    orders={orders}
-                />
-            </div>
-        </Template>
-    );
+    interval;
+
+    // define our use functions
+    refreshOrders = () => {
+        fetch(CURRENT_ORDERS_URL)
+        .then(response => response.json())
+        .then(response => {
+            if(response.success) {
+                this.setState({orders: response.orders});
+            } else {
+                console.log('Error getting orders');
+            }
+        });
+    }
+
+    turnOnLiveMode = () => {
+        fetch(LIVE_ORDER_MODE_URL, {
+            method: `POST`
+        })
+    }
+
+    componentDidMount() {
+        // refresh after mounting
+        this.refreshOrders();
+        // clear interval just in case
+        clearInterval(this.interval);
+        // start regular refresh, every 5 seconds
+        this.interval = setInterval(this.refreshOrders, 5000);
+    }
+    componentWillUnmount() {
+        clearInterval(this.interval);
+    }
+
+    render() {
+        return (
+            <Template>
+                <div className="container-fluid">
+                    <button className="btn btn-success" onClick={this.turnOnLiveMode}>Live Mode!</button>
+                    <OrdersList
+                        orders={this.state.orders}
+                    />
+                </div>
+            </Template>
+        );
+    }
 }
+
+export default ViewOrders;


### PR DESCRIPTION
Auto-update the View Orders page every 5 seconds

Fixes [#12](https://github.com/Shift3/react-challenge-project-jan-2022/issues/12)

## Changes
1. Refactor ViewOrders to be a Component instead of a function
2. Add 5 second interval to re-fetch the current orders
3. Added debug button to trigger Live Mode

## Purpose
Page would require a manual refresh to catch new orders

## Approach
Adds a 5 second component refresh

## Testing Steps
- Open the view orders page
- Turn on live mode, or open the Order page in another tab (with [Shift3/#1](https://github.com/Shift3/react-challenge-project-jan-2022/issues/1) fixed) and place an order
- observe that the view orders page updated without player interaction

## Learning
Looked into how to auto refresh, and best practices appeared to be a regular timer. Find out that some of these functions only work if a Component instead of function, so refactored that (looked at view-orders-old for suggestions as well).

This will have a merge conflict with #2 and #8, and maybe #3, due to refactoring ViewOrders.

Closes [Shift3/#12](https://github.com/Shift3/react-challenge-project-jan-2022/issues/12)
